### PR TITLE
Add event-specific callback support to Rcon API

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,8 @@ go get github.com/zMoooooritz/go-let-loose
 Below is an example of how to use the `go-let-loose/rcon` module in a Go project:
 
 ```go
-type Printer struct{}
-
-func (p *Printer) Notify(e hll.Event) {
-  if e.Type() == hll.EVENT_KILL {
-    fmt.Printf("Kill: %s -> %s (%s)\n", e.(*hll.KillEvent).Killer.Name, e.(*hll.KillEvent).Victim.Name, e.(*hll.KillEvent).Weapon.Name)
-  }
+func onKill(e hll.KillEvent) {
+  fmt.Printf("Kill: %s -> %s (%s)\n", e.Killer.Name, e.Victim.Name, e.Weapon.Name)
 }
 
 func main() {
@@ -78,13 +74,12 @@ func main() {
 
   serverName, err := rcn.GetServerName()
   if err == nil {
-    fmt.Printf("Conntected to the Server: %s\n", serverName)
+    fmt.Printf("Connected to the Server: %s\n", serverName)
   } else {
     fmt.Println(err)
   }
 
-  printer := Printer{}
-  rcn.Events.Register(&printer)
+  rcn.OnKill(onKill)
 
   time.Sleep(time.Second)
 

--- a/cmd/go-let-loose-api/main.go
+++ b/cmd/go-let-loose-api/main.go
@@ -24,7 +24,7 @@ func main() {
 	flag.StringVar(&cfg.Password, "password", "", "password of the rcon")
 	flag.Parse()
 
-	rcn, err := rcon.NewRcon(cfg, workerCount)
+	rcn, err := rcon.NewRcon(cfg, workerCount, rcon.WithVerification())
 	if err != nil {
 		logger.Fatal(err)
 		os.Exit(0)

--- a/examples/main.go
+++ b/examples/main.go
@@ -13,12 +13,8 @@ import (
 	"github.com/zMoooooritz/go-let-loose/pkg/rcon"
 )
 
-type Printer struct{}
-
-func (p *Printer) Notify(e hll.Event) {
-	if e.Type() == hll.EVENT_KILL {
-		fmt.Printf("Kill: %s -> %s (%s)\n", e.(*hll.KillEvent).Killer.Name, e.(*hll.KillEvent).Victim.Name, e.(*hll.KillEvent).Weapon.Name)
-	}
+func onKill(e hll.KillEvent) {
+	fmt.Printf("Kill: %s -> %s (%s)\n", e.Killer.Name, e.Victim.Name, e.Weapon.Name)
 }
 
 func main() {
@@ -43,8 +39,7 @@ func main() {
 		fmt.Println(err)
 	}
 
-	printer := Printer{}
-	rcn.Events.Register(&printer)
+	rcn.OnKill(onKill)
 
 	time.Sleep(time.Second)
 

--- a/pkg/rcon/rcon_event_callbacks.go
+++ b/pkg/rcon/rcon_event_callbacks.go
@@ -1,0 +1,113 @@
+package rcon
+
+import "github.com/zMoooooritz/go-let-loose/pkg/hll"
+
+type callbackObserver[T hll.Event] struct {
+	callback func(T)
+}
+
+func (cb callbackObserver[T]) Notify(e hll.Event) {
+	if typedEvent, ok := e.(T); ok {
+		cb.callback(typedEvent)
+	}
+}
+
+func (r *Rcon) OnConnected(callback func(hll.ConnectEvent)) {
+	r.Events.registerEvent(hll.EVENT_CONNECTED, callbackObserver[hll.ConnectEvent]{callback: callback})
+}
+
+func (r *Rcon) OnDisconnected(callback func(hll.DisconnectEvent)) {
+	r.Events.registerEvent(hll.EVENT_DISCONNECTED, callbackObserver[hll.DisconnectEvent]{callback: callback})
+}
+
+func (r *Rcon) OnKill(callback func(hll.KillEvent)) {
+	r.Events.registerEvent(hll.EVENT_KILL, callbackObserver[hll.KillEvent]{callback: callback})
+}
+
+func (r *Rcon) OnDeath(callback func(hll.DeathEvent)) {
+	r.Events.registerEvent(hll.EVENT_DEATH, callbackObserver[hll.DeathEvent]{callback: callback})
+}
+
+func (r *Rcon) OnTeamKill(callback func(hll.TeamKillEvent)) {
+	r.Events.registerEvent(hll.EVENT_TEAMKILL, callbackObserver[hll.TeamKillEvent]{callback: callback})
+}
+
+func (r *Rcon) OnTeamDeath(callback func(hll.TeamDeathEvent)) {
+	r.Events.registerEvent(hll.EVENT_TEAMDEATH, callbackObserver[hll.TeamDeathEvent]{callback: callback})
+}
+
+func (r *Rcon) OnChat(callback func(hll.ChatEvent)) {
+	r.Events.registerEvent(hll.EVENT_CHAT, callbackObserver[hll.ChatEvent]{callback: callback})
+}
+
+func (r *Rcon) OnBan(callback func(hll.BanEvent)) {
+	r.Events.registerEvent(hll.EVENT_BAN, callbackObserver[hll.BanEvent]{callback: callback})
+}
+
+func (r *Rcon) OnKick(callback func(hll.KickEvent)) {
+	r.Events.registerEvent(hll.EVENT_KICK, callbackObserver[hll.KickEvent]{callback: callback})
+}
+
+func (r *Rcon) OnMessage(callback func(hll.MessageEvent)) {
+	r.Events.registerEvent(hll.EVENT_MESSAGE, callbackObserver[hll.MessageEvent]{callback: callback})
+}
+
+func (r *Rcon) OnMatchStart(callback func(hll.MatchStartEvent)) {
+	r.Events.registerEvent(hll.EVENT_MATCHSTART, callbackObserver[hll.MatchStartEvent]{callback: callback})
+}
+
+func (r *Rcon) OnMatchEnd(callback func(hll.MatchEndEvent)) {
+	r.Events.registerEvent(hll.EVENT_MATCHEND, callbackObserver[hll.MatchEndEvent]{callback: callback})
+}
+
+func (r *Rcon) OnEnterAdminCam(callback func(hll.AdminCamEnteredEvent)) {
+	r.Events.registerEvent(hll.EVENT_ENTER_ADMINCAM, callbackObserver[hll.AdminCamEnteredEvent]{callback: callback})
+}
+
+func (r *Rcon) OnLeaveAdminCam(callback func(hll.AdminCamLeftEvent)) {
+	r.Events.registerEvent(hll.EVENT_LEAVE_ADMINCAM, callbackObserver[hll.AdminCamLeftEvent]{callback: callback})
+}
+
+func (r *Rcon) OnVoteKickStarted(callback func(hll.VoteStartedEvent)) {
+	r.Events.registerEvent(hll.EVENT_VOTE_KICK_STARTED, callbackObserver[hll.VoteStartedEvent]{callback: callback})
+}
+
+func (r *Rcon) OnVoteSubmitted(callback func(hll.VoteSubmittedEvent)) {
+	r.Events.registerEvent(hll.EVENT_VOTE_SUBMITTED, callbackObserver[hll.VoteSubmittedEvent]{callback: callback})
+}
+
+func (r *Rcon) OnVoteKickCompleted(callback func(hll.VoteCompletedEvent)) {
+	r.Events.registerEvent(hll.EVENT_VOTE_KICK_COMPLETED, callbackObserver[hll.VoteCompletedEvent]{callback: callback})
+}
+
+func (r *Rcon) OnTeamSwitched(callback func(hll.PlayerSwitchTeamEvent)) {
+	r.Events.registerEvent(hll.EVENT_TEAM_SWITCHED, callbackObserver[hll.PlayerSwitchTeamEvent]{callback: callback})
+}
+
+func (r *Rcon) OnSquadSwitched(callback func(hll.PlayerSwitchSquadEvent)) {
+	r.Events.registerEvent(hll.EVENT_SQUAD_SWITCHED, callbackObserver[hll.PlayerSwitchSquadEvent]{callback: callback})
+}
+
+func (r *Rcon) OnScoreUpdate(callback func(hll.PlayerScoreUpdateEvent)) {
+	r.Events.registerEvent(hll.EVENT_SCORE_UPDATE, callbackObserver[hll.PlayerScoreUpdateEvent]{callback: callback})
+}
+
+func (r *Rcon) OnRoleChanged(callback func(hll.PlayerChangeRoleEvent)) {
+	r.Events.registerEvent(hll.EVENT_ROLE_CHANGED, callbackObserver[hll.PlayerChangeRoleEvent]{callback: callback})
+}
+
+func (r *Rcon) OnLoadoutChanged(callback func(hll.PlayerChangeLoadoutEvent)) {
+	r.Events.registerEvent(hll.EVENT_LOADOUT_CHANGED, callbackObserver[hll.PlayerChangeLoadoutEvent]{callback: callback})
+}
+
+func (r *Rcon) OnObjectiveCapped(callback func(hll.ObjectiveCaptureEvent)) {
+	r.Events.registerEvent(hll.EVENT_OBJECTIVE_CAPPED, callbackObserver[hll.ObjectiveCaptureEvent]{callback: callback})
+}
+
+func (r *Rcon) OnPositionChanged(callback func(hll.PlayerPositionChangedEvent)) {
+	r.Events.registerEvent(hll.EVENT_POSITION_CHANGED, callbackObserver[hll.PlayerPositionChangedEvent]{callback: callback})
+}
+
+func (r *Rcon) OnClanTagChanged(callback func(hll.PlayerClanTagChangedEvent)) {
+	r.Events.registerEvent(hll.EVENT_CLAN_TAG_CHANGED, callbackObserver[hll.PlayerClanTagChangedEvent]{callback: callback})
+}

--- a/pkg/rcon/rcon_logs_parser.go
+++ b/pkg/rcon/rcon_logs_parser.go
@@ -48,7 +48,7 @@ var logEventParsers = map[hll.EventType]func(time.Time, string) []hll.Event{
 	hll.EVENT_MATCHEND:     logToMatchEndEvent,
 	event_admincam:         logToAdminCamEvent,
 	event_vote:             logToVoteEvents,
-	// hll.EVENT_TEAMSWITCH:   logToTeamSwitchEvent,
+	event_teamswitch:       logToTeamSwitchEvent,
 }
 
 func logToConnectEvent(time time.Time, eventdata string) []hll.Event {
@@ -159,25 +159,28 @@ func teamKillToTeamDeathEvent(teamKillEvent hll.TeamKillEvent) hll.TeamDeathEven
 	}
 }
 
-// func logToTeamSwitchEvent(time time.Time, eventdata string) []hll.Event {
-// 	match := switchPattern.FindStringSubmatch(eventdata)
-// 	if len(match) < 4 {
-// 		logger.Error("Event data unparseable:", eventdata)
-// 		return []hll.Event{}
-// 	}
-// 	return []hll.Event{hll.TeamSwitchEvent{
-// 		GenericEvent: hll.GenericEvent{
-// 			EventType: event_teamswitch,
-// 			EventTime: time,
-// 		},
-// 		Player: hll.PlayerInfo{
-// 			Name: match[1],
-// 			ID:   hll.NoPlayerID,
-// 		},
-// 		From: hll.Team(match[2]),
-// 		To:   hll.Team(match[3]),
-// 	}}
-// }
+func logToTeamSwitchEvent(time time.Time, eventdata string) []hll.Event {
+	// Dont use since a custom event with the player id is implemented
+	return []hll.Event{}
+
+	// match := switchPattern.FindStringSubmatch(eventdata)
+	// if len(match) < 4 {
+	// 	logger.Error("Event data unparseable:", eventdata)
+	// 	return []hll.Event{}
+	// }
+	// return []hll.Event{hll.TeamSwitchEvent{
+	// 	GenericEvent: hll.GenericEvent{
+	// 		EventType: event_teamswitch,
+	// 		EventTime: time,
+	// 	},
+	// 	Player: hll.PlayerInfo{
+	// 		Name: match[1],
+	// 		ID:   hll.NoPlayerID,
+	// 	},
+	// 	From: hll.Team(match[2]),
+	// 	To:   hll.Team(match[3]),
+	// }}
+}
 
 func logToChatEvent(time time.Time, eventdata string) []hll.Event {
 	match := chatPattern.FindStringSubmatch(eventdata)


### PR DESCRIPTION
Introduces a new callback-based mechanism for handling Rcon events, replacing the generic observer pattern. This simplifies event processing by allowing direct function registration for specific event types.

Updates the public API to provide named event callback methods (e.g., `OnKill`, `OnChat`) for better clarity and usability. Ensures backward compatibility by maintaining existing generic observer functionality.

Fixes a typo in a log message and resolves inconsistencies in event registration logic.